### PR TITLE
Refatora status de pedido para enums

### DIFF
--- a/src/main/java/com/example/crm/pedido/PagamentoStatus.java
+++ b/src/main/java/com/example/crm/pedido/PagamentoStatus.java
@@ -1,0 +1,6 @@
+package com.example.crm.pedido;
+
+public enum PagamentoStatus {
+    APROVADO,
+    PENDENTE
+}

--- a/src/main/java/com/example/crm/pedido/PaymentGateway.java
+++ b/src/main/java/com/example/crm/pedido/PaymentGateway.java
@@ -2,9 +2,11 @@ package com.example.crm.pedido;
 
 import org.springframework.stereotype.Service;
 
+import com.example.crm.pedido.PagamentoStatus;
+
 @Service
 public class PaymentGateway {
-    public String process() {
-        return Math.random() > 0.5 ? "APROVADO" : "PENDENTE";
+    public PagamentoStatus process() {
+        return Math.random() > 0.5 ? PagamentoStatus.APROVADO : PagamentoStatus.PENDENTE;
     }
 }

--- a/src/main/java/com/example/crm/pedido/Pedido.java
+++ b/src/main/java/com/example/crm/pedido/Pedido.java
@@ -13,11 +13,13 @@ public class Pedido {
     @ManyToOne
     private Cliente cliente;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private PedidoStatus status;
 
     private Double valorTotal;
 
-    private String pagamentoStatus;
+    @Enumerated(EnumType.STRING)
+    private PagamentoStatus pagamentoStatus;
 
     private LocalDateTime createdAt;
 
@@ -25,14 +27,14 @@ public class Pedido {
     public void setId(Long id) { this.id = id; }
     public Cliente getCliente() { return cliente; }
     public void setCliente(Cliente cliente) { this.cliente = cliente; }
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
+    public PedidoStatus getStatus() { return status; }
+    public void setStatus(PedidoStatus status) { this.status = status; }
 
     public Double getValorTotal() { return valorTotal; }
     public void setValorTotal(Double valorTotal) { this.valorTotal = valorTotal; }
 
-    public String getPagamentoStatus() { return pagamentoStatus; }
-    public void setPagamentoStatus(String pagamentoStatus) { this.pagamentoStatus = pagamentoStatus; }
+    public PagamentoStatus getPagamentoStatus() { return pagamentoStatus; }
+    public void setPagamentoStatus(PagamentoStatus pagamentoStatus) { this.pagamentoStatus = pagamentoStatus; }
 
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/com/example/crm/pedido/PedidoCancellationJob.java
+++ b/src/main/java/com/example/crm/pedido/PedidoCancellationJob.java
@@ -3,6 +3,8 @@ package com.example.crm.pedido;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.example.crm.pedido.PedidoStatus;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -17,9 +19,9 @@ public class PedidoCancellationJob {
     @Scheduled(fixedDelay = 300000)
     public void cancelOldPending() {
         LocalDateTime limit = LocalDateTime.now().minusMinutes(15);
-        List<Pedido> pendentes = repository.findByStatusAndCreatedAtBefore("PENDENTE", limit);
+        List<Pedido> pendentes = repository.findByStatusAndCreatedAtBefore(PedidoStatus.PENDENTE, limit);
         for (Pedido p : pendentes) {
-            p.setStatus("CANCELADO");
+            p.setStatus(PedidoStatus.CANCELADO);
             repository.save(p);
         }
     }

--- a/src/main/java/com/example/crm/pedido/PedidoController.java
+++ b/src/main/java/com/example/crm/pedido/PedidoController.java
@@ -3,6 +3,8 @@ package com.example.crm.pedido;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.example.crm.pedido.PedidoStatus;
+
 import java.util.List;
 
 @RestController
@@ -17,7 +19,7 @@ public class PedidoController {
 
     @PostMapping
     public ResponseEntity<Pedido> create(@RequestBody Pedido p) {
-        p.setStatus("PENDENTE");
+        p.setStatus(PedidoStatus.PENDENTE);
         return ResponseEntity.ok(service.save(p));
     }
 

--- a/src/main/java/com/example/crm/pedido/PedidoRepository.java
+++ b/src/main/java/com/example/crm/pedido/PedidoRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.example.crm.pedido.PedidoStatus;
+
 public interface PedidoRepository extends JpaRepository<Pedido, Long> {
-    List<Pedido> findByStatusAndCreatedAtBefore(String status, LocalDateTime date);
+    List<Pedido> findByStatusAndCreatedAtBefore(PedidoStatus status, LocalDateTime date);
 }

--- a/src/main/java/com/example/crm/pedido/PedidoService.java
+++ b/src/main/java/com/example/crm/pedido/PedidoService.java
@@ -6,6 +6,9 @@ import java.time.LocalDateTime;
 
 import java.util.List;
 
+import com.example.crm.pedido.PagamentoStatus;
+import com.example.crm.pedido.PedidoStatus;
+
 @Service
 public class PedidoService {
     private final PedidoRepository repository;
@@ -20,7 +23,7 @@ public class PedidoService {
 
     public Pedido save(Pedido p) {
         if (p.getStatus() == null) {
-            p.setStatus("CRIADO");
+            p.setStatus(PedidoStatus.CRIADO);
         }
         if (p.getCreatedAt() == null) {
             p.setCreatedAt(LocalDateTime.now());

--- a/src/main/java/com/example/crm/pedido/PedidoStatus.java
+++ b/src/main/java/com/example/crm/pedido/PedidoStatus.java
@@ -1,0 +1,7 @@
+package com.example.crm.pedido;
+
+public enum PedidoStatus {
+    CRIADO,
+    PENDENTE,
+    CANCELADO
+}


### PR DESCRIPTION
## Summary
- introduz enums `PedidoStatus` e `PagamentoStatus`
- ajusta entidade `Pedido` para usar os novos enums
- atualiza controller, repositório, jobs e service com os enums
- converte o gateway de pagamento para retornar `PagamentoStatus`

## Testing
- `./mvnw -q test` *(fails: Maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff7279b0883218095e25647364b7f