### PR TITLE
Implement token persistence

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,15 +1,28 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import apiClient from '../services/apiClient';
 
 export function useAuth() {
-  const [token, setToken] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(
+    sessionStorage.getItem('token')
+  );
+
+  useEffect(() => {
+    if (token) {
+      sessionStorage.setItem('token', token);
+    } else {
+      sessionStorage.removeItem('token');
+    }
+  }, [token]);
 
   const login = async (username: string, password: string) => {
     const res = await apiClient.post('/auth/login', { username, password });
     setToken(res.data.token);
   };
 
-  const logout = () => setToken(null);
+  const logout = () => {
+    sessionStorage.removeItem('token');
+    setToken(null);
+  };
 
   return { token, login, logout };
 }


### PR DESCRIPTION
## Summary
- persist auth token in session storage on login/logout
- sync token updates using a `useEffect`

## Testing
- `./mvnw test` *(fails: Maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514ecc02c883219cbabd79a3f8d356