### PR TITLE
Implement axios auth interceptor

### DIFF
--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -5,4 +5,15 @@ const apiClient = axios.create({
   withCredentials: true,
 });
 
+apiClient.interceptors.request.use((config) => {
+  const token = sessionStorage.getItem('token');
+  if (token) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`,
+    };
+  }
+  return config;
+});
+
 export default apiClient;


### PR DESCRIPTION
## Summary
- add request interceptor in apiClient to load token from `sessionStorage`

## Testing
- `./mvnw test` *(fails: Maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514fb036ac83219b3f52ccae45906b