### PR TITLE
Add Redux auth slice and private routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,21 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './features/Home';
 import Profile from './features/Profile';
+import PrivateRoute from './routes/PrivateRoute';
 import MainLayout from './layouts/MainLayout';
 
 const App: React.FC = () => (
   <Router>
     <MainLayout>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route
+          path="/"
+          element={(
+            <PrivateRoute role="ADMIN">
+              <Home />
+            </PrivateRoute>
+          )}
+        />
         <Route path="/profile" element={<Profile />} />
       </Routes>
     </MainLayout>

--- a/frontend/src/components/organisms/Header/index.tsx
+++ b/frontend/src/components/organisms/Header/index.tsx
@@ -2,16 +2,30 @@ import React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import Button from '../../atoms/Button';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../../hooks/useAuth';
 import './styles.css';
 
-const Header: React.FC = () => (
-  <AppBar position="static">
-    <Toolbar>
-      <Typography variant="h6" component="div">
-        CRM Pizzaria
-      </Typography>
-    </Toolbar>
-  </AppBar>
-);
+const Header: React.FC = () => {
+  const { token, role } = useAuth();
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          CRM Pizzaria
+        </Typography>
+        {token && role === 'ADMIN' && (
+          <Button color="inherit" component={Link} to="/">
+            Home
+          </Button>
+        )}
+        <Button color="inherit" component={Link} to="/profile">
+          {token ? 'Perfil' : 'Login'}
+        </Button>
+      </Toolbar>
+    </AppBar>
+  );
+};
 
 export default Header;

--- a/frontend/src/features/Profile/index.tsx
+++ b/frontend/src/features/Profile/index.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../hooks/useAuth';
 import './styles.css';
 
 const Profile: React.FC = () => {
-  const { token, login, logout } = useAuth();
+  const { token, role, login, logout } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
@@ -19,6 +19,7 @@ const Profile: React.FC = () => {
       {token ? (
         <div>
           <p>Token: {token}</p>
+          {role && <p>Role: {role}</p>}
           <Button variant="contained" onClick={logout}>
             Logout
           </Button>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,28 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../state/redux/hooks';
 import apiClient from '../services/apiClient';
+import { setToken, clearToken } from '../state/redux/slices/authSlice';
 
 export function useAuth() {
-  const [token, setToken] = useState<string | null>(
-    sessionStorage.getItem('token')
-  );
-
-  useEffect(() => {
-    if (token) {
-      sessionStorage.setItem('token', token);
-    } else {
-      sessionStorage.removeItem('token');
-    }
-  }, [token]);
+  const dispatch = useAppDispatch();
+  const token = useAppSelector((state) => state.auth.token);
+  const role = useAppSelector((state) => state.auth.role);
 
   const login = async (username: string, password: string) => {
     const res = await apiClient.post('/auth/login', { username, password });
-    setToken(res.data.token);
+    dispatch(setToken(res.data.token));
   };
 
   const logout = () => {
-    sessionStorage.removeItem('token');
-    setToken(null);
+    dispatch(clearToken());
   };
 
-  return { token, login, logout };
+  return { token, role, login, logout };
 }

--- a/frontend/src/routes/PrivateRoute.tsx
+++ b/frontend/src/routes/PrivateRoute.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+  role?: string;
+}
+
+const PrivateRoute: React.FC<PrivateRouteProps> = ({ children, role }) => {
+  const { token, role: userRole } = useAuth();
+
+  if (!token) {
+    return <Navigate to="/profile" replace />;
+  }
+
+  if (role && userRole !== role) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export default PrivateRoute;

--- a/frontend/src/state/redux/configureStore.ts
+++ b/frontend/src/state/redux/configureStore.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import sampleSlice from './slices/sampleSlice';
+import authReducer from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
     sample: sampleSlice,
+    auth: authReducer,
   },
 });
 

--- a/frontend/src/state/redux/slices/authSlice.ts
+++ b/frontend/src/state/redux/slices/authSlice.ts
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  token: string | null;
+  role: string | null;
+}
+
+function parseJwt(token: string): any {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return {};
+  }
+}
+
+const initialToken = sessionStorage.getItem('token');
+const initialRole = initialToken
+  ? (parseJwt(initialToken).role as string | undefined)?.replace('ROLE_', '') || null
+  : null;
+
+const initialState: AuthState = {
+  token: initialToken,
+  role: initialRole,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setToken(state, action: PayloadAction<string | null>) {
+      state.token = action.payload;
+      if (action.payload) {
+        sessionStorage.setItem('token', action.payload);
+        const payload = parseJwt(action.payload);
+        state.role = payload.role ? String(payload.role).replace('ROLE_', '') : null;
+      } else {
+        sessionStorage.removeItem('token');
+        state.role = null;
+      }
+    },
+    clearToken(state) {
+      state.token = null;
+      state.role = null;
+      sessionStorage.removeItem('token');
+    },
+  },
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- manage token and role through a new Redux slice
- expose auth state via a custom hook
- implement `<PrivateRoute>` to guard routes by role
- show conditional menu items depending on user role
- protect home route for ADMIN users

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685150e459b88321b7b7b7cd87480464