### PR TITLE
Add auth integration tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app/src/test/java/com/example/crm/auth/AuthControllerIT.java
+++ b/app/src/test/java/com/example/crm/auth/AuthControllerIT.java
@@ -1,0 +1,67 @@
+package com.example.crm.auth;
+
+import com.example.crm.usuario.UsuarioRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class AuthControllerIT {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private String baseUrl() {
+        return "http://localhost:" + port + "/v1/auth";
+    }
+
+    @Test
+    void registerAndLoginFlow() {
+        RegisterRequest req = new RegisterRequest();
+        req.setUsername("john@example.com");
+        req.setPassword("password");
+
+        ResponseEntity<Usuario> registerResponse = restTemplate.postForEntity(
+                baseUrl() + "/register/client", req, Usuario.class);
+        assertThat(registerResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(usuarioRepository.findByUsername("john@example.com")).isPresent();
+
+        LoginRequest login = new LoginRequest();
+        login.setUsername("john@example.com");
+        login.setPassword("password");
+        ResponseEntity<TokenResponse> loginResponse = restTemplate.postForEntity(
+                baseUrl() + "/login", login, TokenResponse.class);
+        assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(loginResponse.getBody()).isNotNull();
+        String token = loginResponse.getBody().getToken();
+        assertThat(token).isNotBlank();
+        assertThat(jwtService.extractUsername(token)).isEqualTo("john@example.com");
+    }
+
+    @Test
+    void duplicateRegistrationReturnsConflict() {
+        RegisterRequest req = new RegisterRequest();
+        req.setUsername("dup@example.com");
+        req.setPassword("password");
+        restTemplate.postForEntity(baseUrl() + "/register/client", req, Usuario.class);
+
+        ResponseEntity<String> second = restTemplate.postForEntity(baseUrl() + "/register/client", req, String.class);
+        assertThat(second.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+}

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate.dialect: org.hibernate.dialect.H2Dialect
+jwt:
+  secret: secretsecretsecretsecretsecretsecret


### PR DESCRIPTION
## Summary
- add H2 dependency for tests
- add application.yml for integration tests
- implement AuthController integration tests for registration and login flows

## Testing
- `./mvnw test` *(fails: Maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223fa3a188321a13b7328965d7330